### PR TITLE
Includes a Missing Character in `docker-compose.yaml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - WALLET_PASSWORD=$miningWalletPassword
       - WALLET_MNEMONIC=$miningWalletMnemonic
       - PRINT_MNEMONIC=$printMnemonic
-      - TRANSFER_ADDRESS=$miningTransferAddres
+      - TRANSFER_ADDRESS=$miningTransferAddress
 
 # Timeserie db for storing the metrics
   prometheus:


### PR DESCRIPTION
That previously broke the .env file assignment of the `miningTransferAddress`